### PR TITLE
Specify v1.0.0 of Python springcloudstream module

### DIFF
--- a/python-app-starters-common/src/test/resources/my-python-app/requirements.txt
+++ b/python-app-starters-common/src/test/resources/my-python-app/requirements.txt
@@ -1,1 +1,1 @@
-springcloudstream>=1.0
+springcloudstream==1.0.0

--- a/python-app-starters-common/src/test/resources/python-apps/app1/requirements.txt
+++ b/python-app-starters-common/src/test/resources/python-apps/app1/requirements.txt
@@ -1,1 +1,1 @@
-springcloudstream>=1.0
+springcloudstream==1.0.0

--- a/python-app-starters-common/src/test/resources/python-apps/app2/requirements.txt
+++ b/python-app-starters-common/src/test/resources/python-apps/app2/requirements.txt
@@ -1,1 +1,1 @@
-springcloudstream>=1.0
+springcloudstream==1.0.0

--- a/python-app-starters-common/src/test/resources/python/requirements.txt
+++ b/python-app-starters-common/src/test/resources/python/requirements.txt
@@ -1,1 +1,1 @@
-springcloudstream>=1.0.0
+springcloudstream==1.0.0

--- a/python-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/python/SpringCloudStreamPythonAvailableRule.java
+++ b/python-app-starters-test-support/src/main/java/org/springframework/cloud/stream/app/test/python/SpringCloudStreamPythonAvailableRule.java
@@ -16,6 +16,8 @@
 
 package org.springframework.cloud.stream.app.test.python;
 
+import org.springframework.util.StringUtils;
+
 import java.io.BufferedReader;
 import java.io.InputStream;
 import java.io.InputStreamReader;
@@ -27,7 +29,15 @@ public class SpringCloudStreamPythonAvailableRule extends PythonAvailableRule {
 	public static final String SPRINGCLOUDSTREAM_PYTHON_MODULE = "springcloudstream";
 
 	public SpringCloudStreamPythonAvailableRule() {
-		super("pip", "install", SPRINGCLOUDSTREAM_PYTHON_MODULE);
+		this(null);
+	}
+
+
+	public SpringCloudStreamPythonAvailableRule(String version) {
+
+		super("pip", "install", SPRINGCLOUDSTREAM_PYTHON_MODULE +
+				(StringUtils.hasText(version)? ("=="+version):""));
+
 		processBuilder.redirectErrorStream(true);
 	}
 

--- a/spring-cloud-starter-stream-common-shell/src/test/java/org/springframework/cloud/stream/shell/ShellCommandProcessorTests.java
+++ b/spring-cloud-starter-stream-common-shell/src/test/java/org/springframework/cloud/stream/shell/ShellCommandProcessorTests.java
@@ -45,7 +45,8 @@ public class ShellCommandProcessorTests {
 	private AbstractByteArraySerializer serializer = new ByteArrayCrLfSerializer();
 
 	@ClassRule
-	public static SpringCloudStreamPythonAvailableRule pythonAvailableRule = new SpringCloudStreamPythonAvailableRule();
+	public static SpringCloudStreamPythonAvailableRule pythonAvailableRule = new SpringCloudStreamPythonAvailableRule
+			("1.0.0");
 
 	@BeforeClass
 	public static void init() {

--- a/spring-cloud-starter-stream-processor-python-local/src/test/java/org/springframework/cloud/stream/app/python/local/processor/PythonProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-python-local/src/test/java/org/springframework/cloud/stream/app/python/local/processor/PythonProcessorTests.java
@@ -54,7 +54,7 @@ public abstract class PythonProcessorTests {
 
 	@ClassRule
 	public static SpringCloudStreamPythonAvailableRule springCloudStreamPythonAvailableRule
-			= new SpringCloudStreamPythonAvailableRule();
+			= new SpringCloudStreamPythonAvailableRule("1.0.0");
 
 	@Autowired
 	Processor processor;

--- a/spring-cloud-starter-stream-processor-python-local/src/test/resources/python/requirements.txt
+++ b/spring-cloud-starter-stream-processor-python-local/src/test/resources/python/requirements.txt
@@ -1,1 +1,1 @@
-springcloudstream>=1.0.0
+springcloudstream==1.0.0


### PR DESCRIPTION
This is needed to specify the `1.0.0` version of the Python `springcloudstream` module prior to publishing the `tcp` implementation as `1.1.0` (a breaking change) to the Pypi repo.  This addresses https://github.com/spring-cloud-stream-app-starters/python/issues/2