### PR TITLE
Fix when basedir is set and log the absolute script path

### DIFF
--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
@@ -538,8 +538,17 @@ public class JGitResourceRepository implements InitializingBean {
 				dir = Files.createTempDirectory(prefix).toFile();
 			}
 			else {
-				getBasedir().mkdirs();
-				dir = Files.createTempDirectory(Paths.get(getBasedir().toURI()), prefix).toFile();
+				/*
+				 * If provided base dir is an existing directory than put the repo in a temporary directory that will
+				 * be deleted, otherwise use the provided directory.
+				 */
+				if (getBasedir().exists()) {
+
+					dir = Files.createTempDirectory(Paths.get(getBasedir().toURI()), prefix).toFile();
+				} else {
+					dir = getBasedir();
+					dir.mkdirs();
+				}
 			}
 			Runtime.getRuntime().addShutdownHook(new Thread() {
 				@Override

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
@@ -240,6 +240,9 @@ public class JGitResourceRepository implements InitializingBean {
 
 	@Override
 	public void afterPropertiesSet() throws Exception {
+		if (initialized) {
+			return;
+		}
 		Assert.state(getUri() != null, "You need to configure a uri for the git repository");
 		initialize();
 		if (this.cloneOnStart) {

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
@@ -15,6 +15,9 @@
  */
 package org.springframework.cloud.stream.app.common.resource.repository;
 
+import static org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode.TRACK;
+import static org.springframework.util.StringUtils.hasText;
+
 import com.jcraft.jsch.Session;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -51,12 +54,10 @@ import org.springframework.util.StringUtils;
 import java.io.File;
 import java.io.IOException;
 import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
-
-import static org.eclipse.jgit.api.CreateBranchCommand.SetupUpstreamMode.TRACK;
-import static org.springframework.util.StringUtils.hasText;
 
 /**
  * A Resource provider backed by a single git repository.
@@ -157,6 +158,7 @@ public class JGitResourceRepository implements InitializingBean {
 	}
 
 	public void setBasedir(File basedir) {
+
 		this.basedir = basedir.getAbsoluteFile();
 	}
 
@@ -310,7 +312,7 @@ public class JGitResourceRepository implements InitializingBean {
 	 */
 	private void initClonedRepository() throws GitAPIException, IOException {
 		if (!getUri().startsWith(FILE_URI_PREFIX)) {
-			deleteBaseDirIfExists();
+			//deleteLocalRepoIfExists();
 			Git git = cloneToBasedir();
 			if (git != null) {
 				git.close();
@@ -357,7 +359,7 @@ public class JGitResourceRepository implements InitializingBean {
 	@SuppressWarnings("unchecked")
 	private void logDirty(Status status) {
 		Set<String> dirties = dirties(status.getAdded(), status.getChanged(), status.getRemoved(), status.getMissing(),
-				status.getModified(), status.getConflicting(), status.getUntracked());
+			status.getModified(), status.getConflicting(), status.getUntracked());
 		this.logger.warn(String.format("Dirty files found: %s", dirties));
 	}
 
@@ -385,13 +387,13 @@ public class JGitResourceRepository implements InitializingBean {
 			FetchResult result = fetch.call();
 			if (result.getTrackingRefUpdates() != null && result.getTrackingRefUpdates().size() > 0) {
 				logger.info("Fetched for remote " + branch + " and found " + result.getTrackingRefUpdates().size()
-						+ " updates");
+					+ " updates");
 			}
 			return result;
 		}
 		catch (Exception ex) {
 			String message = "Could not fetch remote for " + branch + " remote: " + git.getRepository().getConfig()
-					.getString("remote", "origin", "url");
+				.getString("remote", "origin", "url");
 			warn(message, ex);
 			return null;
 		}
@@ -409,7 +411,7 @@ public class JGitResourceRepository implements InitializingBean {
 		}
 		catch (Exception ex) {
 			String message = "Could not merge remote for " + branch + " remote: " + git.getRepository().getConfig()
-					.getString("remote", "origin", "url");
+				.getString("remote", "origin", "url");
 			warn(message, ex);
 			return null;
 		}
@@ -427,8 +429,9 @@ public class JGitResourceRepository implements InitializingBean {
 			return resetRef;
 		}
 		catch (Exception ex) {
-			String message = "Could not reset to remote for " + branch + " (current ref=" + ref + "), remote: " + git
-					.getRepository().getConfig().getString("remote", "origin", "url");
+			String message =
+				"Could not reset to remote for " + branch + " (current ref=" + ref + "), remote: " + git.getRepository()
+					.getConfig().getString("remote", "origin", "url");
 			warn(message, ex);
 			return null;
 		}
@@ -447,7 +450,7 @@ public class JGitResourceRepository implements InitializingBean {
 	// together (this is a once only operation, so it only holds things up on the first
 	// request).
 	private synchronized Git copyRepository() throws IOException, GitAPIException {
-		deleteBaseDirIfExists();
+		deleteLocalRepoIfExists();
 		getBasedir().mkdirs();
 		Assert.state(getBasedir().exists(), "Could not create basedir: " + getBasedir());
 		if (getUri().startsWith(FILE_URI_PREFIX)) {
@@ -490,19 +493,19 @@ public class JGitResourceRepository implements InitializingBean {
 
 	private Git cloneToBasedir() throws GitAPIException {
 		CloneCommand clone = this.gitFactory.getCloneCommandByCloneRepository().setURI(getUri())
-				.setDirectory(getBasedir());
+			.setDirectory(this.basedir);
 		setTimeout(clone);
 		setCredentialsProvider(clone);
 		try {
 			return clone.call();
 		}
 		catch (GitAPIException e) {
-			deleteBaseDirIfExists();
+			deleteLocalRepoIfExists();
 			throw e;
 		}
 	}
 
-	private void deleteBaseDirIfExists() {
+	private void deleteLocalRepoIfExists() {
 		if (this.basedir.exists()) {
 			try {
 				FileUtils.delete(getBasedir(), FileUtils.RECURSIVE);
@@ -515,7 +518,9 @@ public class JGitResourceRepository implements InitializingBean {
 
 	private void initialize() {
 		if (!this.initialized) {
-			this.basedir = createBaseDir();
+
+			this.basedir = createTempBasedir();
+
 			SshSessionFactory.setInstance(new JschConfigSessionFactory() {
 				@Override
 				protected void configure(Host hc, Session session) {
@@ -526,9 +531,16 @@ public class JGitResourceRepository implements InitializingBean {
 		}
 	}
 
-	private File createBaseDir() {
+	private File createTempBasedir() {
 		try {
-			final File dir = Files.createTempDirectory(prefix).toFile();
+			final File dir;
+			if (StringUtils.isEmpty(getBasedir())) {
+				dir = Files.createTempDirectory(prefix).toFile();
+			}
+			else {
+				getBasedir().mkdirs();
+				dir = Files.createTempDirectory(Paths.get(getBasedir().toURI()), prefix).toFile();
+			}
 			Runtime.getRuntime().addShutdownHook(new Thread() {
 				@Override
 				public void run() {
@@ -573,8 +585,8 @@ public class JGitResourceRepository implements InitializingBean {
 		}
 		catch (Exception e) {
 			String message =
-					"Could not execute status command on local repository. Cause: (" + e.getClass().getSimpleName()
-							+ ") " + e.getMessage();
+				"Could not execute status command on local repository. Cause: (" + e.getClass().getSimpleName() + ") "
+					+ e.getMessage();
 			warn(message, e);
 			return false;
 		}

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
@@ -312,7 +312,7 @@ public class JGitResourceRepository implements InitializingBean {
 	 */
 	private void initClonedRepository() throws GitAPIException, IOException {
 		if (!getUri().startsWith(FILE_URI_PREFIX)) {
-			//deleteLocalRepoIfExists();
+			deleteLocalRepoIfExists();
 			Git git = cloneToBasedir();
 			if (git != null) {
 				git.close();

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptExecutor.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptExecutor.java
@@ -39,7 +39,7 @@ import java.util.Map;
 public class JythonScriptExecutor implements InitializingBean {
 	private final static Log logger = LogFactory.getLog(JythonScriptExecutor.class);
 	private final ScriptVariableGenerator variableGenerator;
-	private final SimpleStringScriptSource script;
+	private SimpleStringScriptSource script;
 	private final PythonScriptExecutor scriptExecutor;
 	private final Map<String, Object> staticVariables = new HashMap<>();
 
@@ -50,12 +50,16 @@ public class JythonScriptExecutor implements InitializingBean {
 	public JythonScriptExecutor(Resource resource, ScriptVariableGenerator variableGenerator) {
 
 		ScriptSource scriptSource = new ResourceScriptSource(resource);
-
+		String scriptPath = null;
 		try {
+			scriptPath = resource.getFile().getAbsolutePath();
+			logger.debug( String.format("Loading script %s", scriptPath) );
 			this.script = new SimpleStringScriptSource(scriptSource.getScriptAsString());
 		}
 		catch (IOException e) {
-			throw new IllegalArgumentException(String.format("Cannot access script %s", resource.getFilename()));
+			String errorMessage = String.format("Cannot access script %s", scriptPath);
+			logger.error(errorMessage);
+			throw new IllegalArgumentException(errorMessage);
 		}
 
 		this.scriptExecutor = new PythonScriptExecutor();

--- a/spring-cloud-starter-stream-processor-python-http/README.adoc
+++ b/spring-cloud-starter-stream-processor-python-http/README.adoc
@@ -105,8 +105,8 @@ $$httpclient.body$$:: $$The (static) request body; if neither this nor bodyExpre
 $$httpclient.body-expression$$:: $$A SpEL expression to derive the request body from the incoming message.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$httpclient.expected-response-type$$:: $$The type used to interpret the response.$$ *($$Class<?>$$, default: `$$<none>$$`)*
 $$httpclient.headers-expression$$:: $$A SpEL expression used to derive the http headers map to use.$$ *($$Expression$$, default: `$$<none>$$`)*
-$$httpclient.http-method$$:: $$The kind of http method to use.$$ *($$HttpMethod)$$, default: `$$<none>$$`)*
-$$httpclient.reply-expression$$:: $$A SpEL expression used to compute the final result, applied against the whole http response.$$ *($$Expression)$$, default: `$$body$$`)*
+$$httpclient.http-method$$:: $$The kind of http method to use.$$ *($$HttpMethod$$, default: `$$<none>$$`, possible values: `GET`,`HEAD`,`POST`,`PUT`,`PATCH`,`DELETE`,`OPTIONS`,`TRACE`)*
+$$httpclient.reply-expression$$:: $$A SpEL expression used to compute the final result, applied against the whole http response.$$ *($$Expression$$, default: `$$body$$`)*
 $$httpclient.url$$:: $$The URL to issue an http request to, as a static value.$$ *($$String$$, default: `$$<none>$$`)*
 $$httpclient.url-expression$$:: $$A SpEL expression against incoming message to determine the URL to use.$$ *($$Expression$$, default: `$$<none>$$`)*
 $$wrapper.content-type$$:: $$Sets the Content type header for the outgoing Message.$$ *($$MediaType$$, default: `$$<none>$$`)*


### PR DESCRIPTION
This may fix the issue when running on K8s since it correctly applies `git.basedir` if provided. For example if `--git.uri=.... --git.basedir=/foo/bar`, the app will pull from the git repo to `foo/bar/resource_repo<someRandomString>` . NOTE, this directory will be deleted when the application exits.  If the error described in #12 happens, the full path will be logged.  It appears, the container is able to access the git url but there may be an issue related to the local volume configuration.     

NOTE setting `logging.level.org.springframework.cloud.stream.app.python.jython=DEBUG` will log the full path before the ScriptExecutor attempts to load the script. 

Fixes #12 