### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ Spring Cloud Stream App Starters for integrating with Python
 === Provisioning Python Resources
 
 Each of the applications in the Python family include configuration properties that specify Python(Jython) script
-location and directory path. These properties use Spring's http://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html[Resource] abstraction.
+location and directory path. These properties use Spring's https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html[Resource] abstraction.
 Python script and directory locations may reference a local file or URL resource (e.g. http). Classpath resources are
 intentionally not supported as it would require a Python developer to package Python scripts in the jar. Scripts may
 be optionally downloaded from a git repository. If you provide a valid `git.uri` to the repository, the application will clone the repository

--- a/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
+++ b/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
@@ -31,10 +31,10 @@ public class Page {
 
 	public Page() {
 		try {
-			links.put("google", new URI("http://www.google.com"));
-			links.put("yahoo", new URI("http://www.yahoo.com"));
-			links.put("pivotal", new URI("http://www.pivotal.io"));
-			links.put("spring", new URI("http://www.spring.io"));
+			links.put("google", new URI("https://www.google.com"));
+			links.put("yahoo", new URI("https://www.yahoo.com"));
+			links.put("pivotal", new URI("https://www.pivotal.io"));
+			links.put("spring", new URI("https://www.spring.io"));
 
 			images.put("image1", "image1.gif");
 			images.put("image2", "image2.gif");

--- a/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepositoryTests.java
+++ b/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepositoryTests.java
@@ -160,7 +160,7 @@ public class JGitResourceRepositoryTests {
 
 		JGitResourceRepository resourceRepository = new JGitResourceRepository();
 		resourceRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
-		resourceRepository.setUri("http://somegitserver/somegitrepo");
+		resourceRepository.setUri("https://somegitserver/somegitrepo");
 		resourceRepository.setCloneOnStart(true);
 		resourceRepository.afterPropertiesSet();
 		verify(mockCloneCommand, times(1)).call();
@@ -177,7 +177,7 @@ public class JGitResourceRepositoryTests {
 		JGitResourceRepository resourceRepository = new JGitResourceRepository();
 		resourceRepository.setCloneOnStart(false);
 		resourceRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
-		resourceRepository.setUri("http://somegitserver/somegitrepo");
+		resourceRepository.setUri("https://somegitserver/somegitrepo");
 		resourceRepository.afterPropertiesSet();
 		verify(mockCloneCommand, times(0)).call();
 		verify(mockGit, times(0)).fetch();
@@ -212,7 +212,7 @@ public class JGitResourceRepositoryTests {
 		when(git.status()).thenReturn(statusCommand);
 		when(git.getRepository()).thenReturn(repository);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(false);
 
@@ -235,7 +235,7 @@ public class JGitResourceRepositoryTests {
 		when(git.status()).thenReturn(statusCommand);
 		when(git.getRepository()).thenReturn(repository);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(false);
 
@@ -257,7 +257,7 @@ public class JGitResourceRepositoryTests {
 		when(git.status()).thenReturn(statusCommand);
 		when(git.getRepository()).thenReturn(repository);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(true);
 
@@ -285,7 +285,7 @@ public class JGitResourceRepositoryTests {
 		when(git.getRepository()).thenReturn(repository);
 		StoredConfig storedConfig = mock(StoredConfig.class);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(true);
 
@@ -318,7 +318,7 @@ public class JGitResourceRepositoryTests {
 		when(headRef.getObjectId()).thenReturn(newObjectId);
 
 		this.repository.setGitFactory(factory);
-		this.repository.setUri("http://example/git");
+		this.repository.setUri("https://example/git");
 		this.repository.setCloneOnStart(false);
 		this.repository.afterPropertiesSet();
 
@@ -349,7 +349,7 @@ public class JGitResourceRepositoryTests {
 		when(git.getRepository()).thenReturn(repository);
 		StoredConfig storedConfig = mock(StoredConfig.class);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(true);
 
@@ -388,7 +388,7 @@ public class JGitResourceRepositoryTests {
 		when(headRef.getObjectId()).thenReturn(newObjectId);
 
 		this.repository.setGitFactory(factory);
-		this.repository.setUri("http://example/git");
+		this.repository.setUri("https://example/git");
 		this.repository.setCloneOnStart(false);
 		this.repository.afterPropertiesSet();
 
@@ -422,7 +422,7 @@ public class JGitResourceRepositoryTests {
 		when(git.getRepository()).thenReturn(repository);
 		StoredConfig storedConfig = mock(StoredConfig.class);
 		when(repository.getConfig()).thenReturn(storedConfig);
-		when(storedConfig.getString("remote", "origin", "url")).thenReturn("http://example/git");
+		when(storedConfig.getString("remote", "origin", "url")).thenReturn("https://example/git");
 		when(statusCommand.call()).thenReturn(status);
 		when(status.isClean()).thenReturn(true).thenReturn(false);
 
@@ -463,7 +463,7 @@ public class JGitResourceRepositoryTests {
 		when(headRef.getObjectId()).thenReturn(newObjectId);
 
 		this.repository.setGitFactory(factory);
-		this.repository.setUri("http://example/git");
+		this.repository.setUri("https://example/git");
 		this.repository.setCloneOnStart(false);
 		this.repository.afterPropertiesSet();
 
@@ -488,7 +488,7 @@ public class JGitResourceRepositoryTests {
 
 		JGitResourceRepository resourceRepository = new JGitResourceRepository();
 		resourceRepository.setGitFactory(new MockGitFactory(mockGit, mockCloneCommand));
-		resourceRepository.setUri("http://somegitserver/somegitrepo");
+		resourceRepository.setUri("https://somegitserver/somegitrepo");
 		resourceRepository.setBasedir(this.basedir);
 		resourceRepository.setCloneOnStart(false);
 		resourceRepository.afterPropertiesSet();

--- a/spring-cloud-starter-stream-processor-python-http/README.adoc
+++ b/spring-cloud-starter-stream-processor-python-http/README.adoc
@@ -130,11 +130,11 @@ See https://github.com/spring-cloud-stream-app-starters/httpclient[httpclient pr
 
 [source, bash]
 ----
-$java -jar python-http-processor.jar --wrapper.script=/local/directory/build-json.py --httpclient.url=http://someurl
+$java -jar python-http-processor.jar --wrapper.script=/local/directory/build-json.py --httpclient.url=https://someurl
 --httpclient.http-method=POST --httpclient.headers-expression="{'Content-Type':'application/json'}"
 
 $java -jar python-http-processor.jar --git.uri=https://github.com/some-repo --wrapper.script=some-script.py --wrapper
-.variables=foo=0.45,bar=0.55 --httpclient.url=http://someurl
+.variables=foo=0.45,bar=0.55 --httpclient.url=https://someurl
 ----
 
 //end::ref-doc[]

--- a/spring-cloud-starter-stream-processor-python-jython/README.adoc
+++ b/spring-cloud-starter-stream-processor-python-jython/README.adoc
@@ -6,7 +6,7 @@ This application executes a Jython script that binds `payload` and `headers` var
 and headers respectively. In addition you may provide a `jython.variables` property containing a (comma delimited by
 default)  delimited string, e.g., `var1=val1,var2=val2,...`.
 
-This processor uses a JSR-223 compliant embedded ScriptEngine provided by http://www.jython.org/.
+This processor uses a JSR-223 compliant embedded ScriptEngine provided by https://www.jython.org/.
 
 [NOTE]
 ====


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://example/git (UnknownHostException) with 9 occurrences migrated to:  
  https://example/git ([https](https://example/git) result UnknownHostException).
* [ ] http://somegitserver/somegitrepo (UnknownHostException) with 3 occurrences migrated to:  
  https://somegitserver/somegitrepo ([https](https://somegitserver/somegitrepo) result UnknownHostException).
* [ ] http://someurl (UnknownHostException) with 2 occurrences migrated to:  
  https://someurl ([https](https://someurl) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.google.com with 1 occurrences migrated to:  
  https://www.google.com ([https](https://www.google.com) result 200).
* [ ] http://www.jython.org/ with 1 occurrences migrated to:  
  https://www.jython.org/ ([https](https://www.jython.org/) result 200).
* [ ] http://www.yahoo.com with 1 occurrences migrated to:  
  https://www.yahoo.com ([https](https://www.yahoo.com) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html) result 301).
* [ ] http://www.pivotal.io with 1 occurrences migrated to:  
  https://www.pivotal.io ([https](https://www.pivotal.io) result 301).
* [ ] http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://localhost with 1 occurrences