### PR TITLE
URL Cleanup

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
                                  Apache License
                            Version 2.0, January 2004
-                        http://www.apache.org/licenses/
+                        https://www.apache.org/licenses/
 
    TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
 
@@ -192,7 +192,7 @@
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepository.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/NoSuchBranchException.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/NoSuchBranchException.java
@@ -6,7 +6,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/config/GitResourceRepositoryConfiguration.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/common/resource/repository/config/GitResourceRepositoryConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptExecutor.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptExecutor.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptProperties.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/JythonScriptProperties.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/ScriptVariableGeneratorConfiguration.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/jython/ScriptVariableGeneratorConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/script/ScriptProperties.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/script/ScriptProperties.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/script/ScriptResourceUtils.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/script/ScriptResourceUtils.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/wrapper/JythonWrapperConfiguration.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/wrapper/JythonWrapperConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/wrapper/JythonWrapperProperties.java
+++ b/python-app-starters-common/src/main/java/org/springframework/cloud/stream/app/python/wrapper/JythonWrapperProperties.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
+++ b/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepositoryTests.java
+++ b/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/common/resource/repository/JGitResourceRepositoryTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/python/wrapper/JythonScriptExecutorTests.java
+++ b/python-app-starters-common/src/test/java/org/springframework/cloud/stream/app/python/wrapper/JythonScriptExecutorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/python-app-starters-common/src/test/resources/logback.xml
+++ b/python-app-starters-common/src/test/resources/logback.xml
@@ -5,7 +5,7 @@
   ~   you may not use this file except in compliance with the License.
   ~   You may obtain a copy of the License at
   ~
-  ~        http://www.apache.org/licenses/LICENSE-2.0
+  ~        https://www.apache.org/licenses/LICENSE-2.0
   ~
   ~   Unless required by applicable law or agreed to in writing, software
   ~   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/HttpJythonProcessorInputConfiguration.java
+++ b/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/HttpJythonProcessorInputConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/HttpJythonProcessorOutputConfiguration.java
+++ b/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/HttpJythonProcessorOutputConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-python-http/src/main/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-http/src/test/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-python-http/src/test/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-jython/src/main/java/org/springframework/cloud/stream/app/python/jython/processor/PythonJythonProcessorConfiguration.java
+++ b/spring-cloud-starter-stream-processor-python-jython/src/main/java/org/springframework/cloud/stream/app/python/jython/processor/PythonJythonProcessorConfiguration.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-jython/src/test/java/org/springframework/cloud/stream/app/python/jython/processor/JythonProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-python-jython/src/test/java/org/springframework/cloud/stream/app/python/jython/processor/JythonProcessorTests.java
@@ -5,7 +5,7 @@
  *   you may not use this file except in compliance with the License.
  *   You may obtain a copy of the License at
  *
- *        http://www.apache.org/licenses/LICENSE-2.0
+ *        https://www.apache.org/licenses/LICENSE-2.0
  *
  *   Unless required by applicable law or agreed to in writing, software
  *   distributed under the License is distributed on an "AS IS" BASIS,

--- a/spring-cloud-starter-stream-processor-python-jython/src/test/resources/wrapper/json-test.py
+++ b/spring-cloud-starter-stream-processor-python-jython/src/test/resources/wrapper/json-test.py
@@ -5,7 +5,7 @@ Copyright 2017 the original author or authors.
    you may not use this file except in compliance with the License.
    You may obtain a copy of the License at
 
-       http://www.apache.org/licenses/LICENSE-2.0
+       https://www.apache.org/licenses/LICENSE-2.0
 
    Unless required by applicable law or agreed to in writing, software
    distributed under the License is distributed on an "AS IS" BASIS,


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.apache.org/licenses/ with 1 occurrences migrated to:  
  https://www.apache.org/licenses/ ([https](https://www.apache.org/licenses/) result 200).
* [ ] http://www.apache.org/licenses/LICENSE-2.0 with 22 occurrences migrated to:  
  https://www.apache.org/licenses/LICENSE-2.0 ([https](https://www.apache.org/licenses/LICENSE-2.0) result 200).