### PR TITLE
URL Cleanup

### DIFF
--- a/CODE_OF_CONDUCT.adoc
+++ b/CODE_OF_CONDUCT.adoc
@@ -40,5 +40,5 @@ appropriate to the circumstances. Maintainers are obligated to maintain confiden
 with regard to the reporter of an incident.
 
 This Code of Conduct is adapted from the
-http://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
-http://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]
+https://contributor-covenant.org[Contributor Covenant], version 1.3.0, available at
+https://contributor-covenant.org/version/1/3/0/[contributor-covenant.org/version/1/3/0/]

--- a/README.adoc
+++ b/README.adoc
@@ -7,7 +7,7 @@ Spring Cloud Stream App Starters for integrating with Python
 === Provisioning Python Resources
 
 Each of the applications in the Python family include configuration properties that specify Python(Jython) script
-location and directory path. These properties use Spring's http://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html[Resource] abstraction.
+location and directory path. These properties use Spring's https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html[Resource] abstraction.
 Python script and directory locations may reference a local file or URL resource (e.g. http). Classpath resources are
 intentionally not supported as it would require a Python developer to package Python scripts in the jar. Scripts may
 be optionally downloaded from a git repository. If you provide a valid `git.uri` to the repository, the application will clone the repository

--- a/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
+++ b/python-app-starters-common/src/test/java/org/spring/io/data/Page.java
@@ -31,10 +31,10 @@ public class Page {
 
 	public Page() {
 		try {
-			links.put("google", new URI("http://www.google.com"));
-			links.put("yahoo", new URI("http://www.yahoo.com"));
-			links.put("pivotal", new URI("http://www.pivotal.io"));
-			links.put("spring", new URI("http://www.spring.io"));
+			links.put("google", new URI("https://www.google.com"));
+			links.put("yahoo", new URI("https://www.yahoo.com"));
+			links.put("pivotal", new URI("https://www.pivotal.io"));
+			links.put("spring", new URI("https://www.spring.io"));
 
 			images.put("image1", "image1.gif");
 			images.put("image2", "image2.gif");

--- a/spring-cloud-starter-stream-processor-python-http/src/test/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorTests.java
+++ b/spring-cloud-starter-stream-processor-python-http/src/test/java/org/springframework/cloud/stream/app/python/http/processor/PythonHttpProcessorTests.java
@@ -101,7 +101,7 @@ public abstract class PythonHttpProcessorTests {
 
 	}
 
-	@TestPropertySource(properties = { "httpclient.url=http://sentiment-compute.cfapps.pez.pivotal.io/polarity_compute",
+	@TestPropertySource(properties = { "httpclient.url=https://sentiment-compute.cfapps.pez.pivotal.io/polarity_compute",
 			"httpclient.httpMethod=POST", "httpclient.headersExpression={'Content-Type' : 'application/json'}",
 			"git.uri=https://github.com/dturanski/python-apps",
 			"wrapper.script=test-wrappers/get-tweet-sentiments-for-http.py" })

--- a/spring-cloud-starter-stream-processor-python-jython/README.adoc
+++ b/spring-cloud-starter-stream-processor-python-jython/README.adoc
@@ -6,7 +6,7 @@ This application executes a Jython script that binds `payload` and `headers` var
 and headers respectively. In addition you may provide a `jython.variables` property containing a (comma delimited by
 default)  delimited string, e.g., `var1=val1,var2=val2,...`.
 
-This processor uses a JSR-223 compliant embedded ScriptEngine provided by http://www.jython.org/.
+This processor uses a JSR-223 compliant embedded ScriptEngine provided by https://www.jython.org/.
 
 [NOTE]
 ====


### PR DESCRIPTION
This commit updates URLs to prefer the https protocol. Redirects are not followed to avoid accidentally expanding intentionally shortened URLs (i.e. if using a URL shortener).

# Fixed URLs

## Fixed But Review Recommended
These URLs were fixed, but the https status was not OK. However, the https status was the same as the http request or http redirected to an https URL, so they were migrated. Your review is recommended.

* [ ] http://sentiment-compute.cfapps.pez.pivotal.io/polarity_compute (UnknownHostException) with 1 occurrences migrated to:  
  https://sentiment-compute.cfapps.pez.pivotal.io/polarity_compute ([https](https://sentiment-compute.cfapps.pez.pivotal.io/polarity_compute) result UnknownHostException).

## Fixed Success 
These URLs were switched to an https URL with a 2xx status. While the status was successful, your review is still recommended.

* [ ] http://www.google.com with 1 occurrences migrated to:  
  https://www.google.com ([https](https://www.google.com) result 200).
* [ ] http://www.jython.org/ with 1 occurrences migrated to:  
  https://www.jython.org/ ([https](https://www.jython.org/) result 200).
* [ ] http://www.yahoo.com with 1 occurrences migrated to:  
  https://www.yahoo.com ([https](https://www.yahoo.com) result 200).
* [ ] http://contributor-covenant.org with 1 occurrences migrated to:  
  https://contributor-covenant.org ([https](https://contributor-covenant.org) result 301).
* [ ] http://contributor-covenant.org/version/1/3/0/ with 1 occurrences migrated to:  
  https://contributor-covenant.org/version/1/3/0/ ([https](https://contributor-covenant.org/version/1/3/0/) result 301).
* [ ] http://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html with 1 occurrences migrated to:  
  https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html ([https](https://docs.spring.io/spring/docs/current/spring-framework-reference/html/resources.html) result 301).
* [ ] http://www.pivotal.io with 1 occurrences migrated to:  
  https://www.pivotal.io ([https](https://www.pivotal.io) result 301).
* [ ] http://www.spring.io with 1 occurrences migrated to:  
  https://www.spring.io ([https](https://www.spring.io) result 301).

# Ignored
These URLs were intentionally ignored.

* http://example/git with 9 occurrences
* http://localhost with 1 occurrences
* http://somegitserver/somegitrepo with 3 occurrences
* http://someurl with 2 occurrences